### PR TITLE
fix: remove Forwardable module

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,68 @@
+name: build
+
+kind: pipeline
+type: docker
+
+volumes:
+  - name: images
+    host:
+      path: /home/data/drone/images
+  - name: bundle
+    host:
+      path: /home/data/drone/gems
+  - name: keys
+    host:
+      path: /home/data/drone/key_cache
+
+spec_step_common: &spec_step_common
+  image: abakpress/dind-testing
+  pull: if-not-exists
+  privileged: true
+  volumes:
+    - name: images
+      path: /images
+    - name: bundle
+      path: /bundle
+    - name: keys
+      path: /ssh_keys
+  commands:
+    - prepare-build
+
+    - fetch-images
+      --image whilp/ssh-agent
+      --image abakpress/ruby-app:$RUBY_IMAGE_TAG
+
+    - dip ssh add -T -v /ssh_keys -k /ssh_keys/id_rsa
+    - dip provision
+    - dip rspec
+
+steps:
+  - name: Tests Ruby 2.2
+    environment:
+      COMPOSE_FILE_EXT: drone
+      DOCKER_RUBY_VERSION: 2.2
+      RUBY_IMAGE_TAG: 2.2-latest
+      RAILS_ENV: test
+      BUNDLER_OPTIONS: " --without 'development production profile console assets' -j 10 --quiet"
+      BUNDLER_VERSION: 1.17.3
+    <<: *spec_step_common
+
+  - name: Tests Ruby 2.3
+    environment:
+      COMPOSE_FILE_EXT: drone
+      DOCKER_RUBY_VERSION: 2.3
+      RUBY_IMAGE_TAG: 2.3-latest
+      RAILS_ENV: test
+      BUNDLER_OPTIONS: " --without 'development production profile console assets' -j 10 --quiet"
+      BUNDLER_VERSION: 1.17.3
+    <<: *spec_step_common
+
+  - name: release
+    image: abakpress/gem-publication:latest
+    pull: if-not-exists
+    when:
+      event: push
+      branch: master
+      status: success
+    commands:
+      - release-gem

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,5 @@
---format documentation
 --color
+--tty
+--format progress
+--order random
+--backtrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.1
-before_install: gem install bundler -v 1.10.6
-addons:
-  code_climate:
-    repo_token: 363fef79ea0d646c43a20ea27d2cc4e3b97c4500023c8dc2ba25b027018a1ec9

--- a/dip.yml
+++ b/dip.yml
@@ -1,0 +1,43 @@
+version: '1'
+
+environment:
+  DOCKER_RUBY_VERSION: 2.3
+  RUBY_IMAGE_TAG: 2.3-latest
+  COMPOSE_FILE_EXT: development
+  RAILS_ENV: test
+  APRESS_GEMS_CREDENTIALS: ""
+
+compose:
+  files:
+    - docker-compose.yml
+    - docker-compose.${COMPOSE_FILE_EXT}.yml
+
+interaction:
+  sh:
+    service: app
+
+  irb:
+    service: app
+    command: irb
+
+  bundle:
+    service: app
+    command: bundle
+
+  rake:
+    service: app
+    command: bundle exec rake
+
+  rspec:
+    service: app
+    command: bundle exec rspec
+
+  clean:
+    service: app
+    command: rm -rf Gemfile.lock gemfiles
+
+provision:
+  - docker volume create --name bundler_data
+  - dip bundle config --local https://gems.railsc.ru/ ${APRESS_GEMS_CREDENTIALS}
+  - dip clean
+  - dip bundle install

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,18 @@
+version: '2'
+
+services:
+  app:
+    volumes:
+      - .:/app
+      - ../:/localgems
+      - bundler-data:/bundle
+      - ssh-data:/ssh:ro
+
+volumes:
+  bundler-data:
+    external:
+      name: bundler_data
+
+  ssh-data:
+    external:
+      name: ssh_data

--- a/docker-compose.drone.yml
+++ b/docker-compose.drone.yml
@@ -1,0 +1,18 @@
+version: '2'
+
+services:
+  app:
+    volumes:
+      - .:/app
+      - bundler-data:/bundle
+      - /bundle:/bundle
+      - ssh-data:/ssh:ro
+
+volumes:
+  ssh-data:
+    external:
+      name: ssh_data
+
+  bundler-data:
+    external:
+      name: bundler_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  app:
+    image: abakpress/ruby-app:$RUBY_IMAGE_TAG
+    environment:
+      - BUNDLE_PATH=/bundle/$DOCKER_RUBY_VERSION
+      - SSH_AUTH_SOCK=/ssh/auth/sock
+    command: bash

--- a/lib/ruby/reports/base_report.rb
+++ b/lib/ruby/reports/base_report.rb
@@ -69,8 +69,6 @@ module Ruby
     #     end
     #   end
     class BaseReport
-      extend Forwardable
-
       class << self
         attr_reader :config_hash, :table_block, :progress_handle_block, :error_handle_block
 
@@ -93,7 +91,6 @@ module Ruby
       end
 
       attr_reader :args, :job_id, :events_handler
-      def_delegators :cache_file, :filename, :exists?, :ready?
 
       #--
       # Public instance methods
@@ -118,6 +115,18 @@ module Ruby
 
       def error_handler(&block)
         @error_handle_block = block
+      end
+
+      def filename
+        cache_file.filename
+      end
+
+      def exists?
+        cache_file.exists?
+      end
+
+      def ready?
+        cache_file.ready?
       end
 
       private

--- a/lib/ruby/reports/config.rb
+++ b/lib/ruby/reports/config.rb
@@ -14,7 +14,8 @@ module Ruby
         :encoding,
         :expire_in,
         :csv_options,
-        :storage
+        :storage,
+        :queue
       ]
 
       def self.config_attributes

--- a/lib/ruby/reports/services/query_builder.rb
+++ b/lib/ruby/reports/services/query_builder.rb
@@ -2,21 +2,19 @@ module Ruby
   module Reports
     module Services
       class QueryBuilder
-        extend Forwardable
         pattr_initialize :report, :config
 
         def request_count
-          execute(count)[0]['count'].to_i
+          connection.execute(count)[0]['count'].to_i
         end
 
         def request_batch(offset)
-          execute take_batch(config.batch_size, offset)
+          connection.execute take_batch(config.batch_size, offset)
         end
 
         private
 
-        def_delegator :connection, :execute
-
+        # TODO: WTF?! Where is AR dependcy? Move to arg of constructor
         def connection
           ActiveRecord::Base.connection
         end

--- a/lib/ruby/reports/version.rb
+++ b/lib/ruby/reports/version.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 module Ruby
   module Reports
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end
 

--- a/ruby-reports.gemspec
+++ b/ruby-reports.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '>= 2.14.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'timecop', '~> 0.7.1'
-  spec.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
 
 require 'ruby/reports'
 require 'simplecov'


### PR DESCRIPTION
because this line https://github.com/ruby/ruby/blob/bbda1a027475bf7ce5e1a9583a7b55d0be71c8fe/lib/forwardable.rb#L187
overrides delegate method from ActiveSupport core_ext

в местах, где инклюдится ActiveModel::Validations падает с ошибкой
```
ArgumentError: wrong number of arguments (2 for 1)
  /usr/local/rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/forwardable.rb:133:in `instance_delegate'
  /bundle/2.2/gems/activemodel-4.2.11.3/lib/active_model/naming.rb:220:in `extended'
  /bundle/2.2/gems/activemodel-4.2.11.3/lib/active_model/validations.rb:42:in `extend'
  /bundle/2.2/gems/activemodel-4.2.11.3/lib/active_model/validations.rb:42:in `block in <module:Validations>'
  /bundle/2.2/gems/activesupport-4.2.11.3/lib/active_support/concern.rb:120:in `class_eval'
  /bundle/2.2/gems/activesupport-4.2.11.3/lib/active_support/concern.rb:120:in `append_features'
  /app/app/services/apress/deals/front/reports/offers_report_service.rb:11:in `include'
  /app/app/services/apress/deals/front/reports/offers_report_service.rb:11:in `<class:OffersReportService>'
```
Это на рельсах 4.2